### PR TITLE
Implement SB2.1 fw version check commands

### DIFF
--- a/example-cfgs/example-cfg.toml
+++ b/example-cfgs/example-cfg.toml
@@ -70,6 +70,14 @@ nonsecure-firmware-version = 1
 # sbkek = "AAAAAAAA AAAAAAAAA AAAAAAAA AAAAAAAA AAAAAAA AAAAAAAA AAAAAAAA AAAAAAAA"
 
 [[commands]]
+cmd = "CheckSecureFirmwareVersion"
+version = 1
+
+[[commands]]
+cmd = "CheckNonsecureFirmwareVersion"
+version = 1
+
+[[commands]]
 cmd = "Erase"
 start = 0x0
 end = 0xC00  # = 3072 = 6*512, size of blinky-red.bin is 856 bytes, signed version is 2148 bytes

--- a/src/secure_binary/command.rs
+++ b/src/secure_binary/command.rs
@@ -164,6 +164,14 @@ pub enum BootCommandDescriptor {
         #[serde(skip_serializing_if = "Option::is_none")]
         len: Option<u32>,
     },
+
+    CheckNonsecureFirmwareVersion {
+        version: u32,
+    },
+
+    CheckSecureFirmwareVersion {
+        version: u32,
+    },
 }
 
 impl<'a> TryFrom<&'a BootCommandDescriptor> for BootCommand {
@@ -189,6 +197,8 @@ impl<'a> TryFrom<&'a BootCommandDescriptor> for BootCommand {
                 BootCommand::Load { address: *dst, data }
 
             }
+            CheckNonsecureFirmwareVersion { version } => BootCommand::CheckNonsecureFirmwareVersion { version: *version },
+            CheckSecureFirmwareVersion { version } => BootCommand::CheckSecureFirmwareVersion { version: *version },
         })
     }
 }
@@ -288,6 +298,8 @@ impl BootCommand {
             }
             CheckSecureFirmwareVersion { version } => {
                 cmd.tag = BootTag::CheckFirmwareVersion as u8;
+                // according to nxp/spsdk
+                cmd.address = 2;
                 cmd.count = *version;
                 Vec::from(cmd.to_bytes().as_ref())
             }


### PR DESCRIPTION
For comparison: https://github.com/NXPmicro/spsdk/blob/13ad8bd80913a035eac48aa848270f7600cb455a/spsdk/sbfile/sb31/commands.py#L484-L506