### PR TITLE
Fix debug policies

### DIFF
--- a/src/protected_flash.rs
+++ b/src/protected_flash.rs
@@ -1156,13 +1156,38 @@ pub struct DebugSecurityPolicies {
 
 impl From<DebugSecurity> for DebugSecurityPolicies {
     fn from(value: DebugSecurity) -> Self {
+        use DebugSecurityPolicy::*;
         match value {
             // Fixed, Disabled
-            DebugSecurity::AllDisabled =>
-                [0xffffu32, 0x0000].into(),
-            // Not fixed, Enabled
-            DebugSecurity::AllEnabled =>
-                [0x0000u32, 0xffff].into(),
+            DebugSecurity::AllDisabled => DebugSecurityPolicies {
+                nonsecure_noninvasive: Disabled,
+                nonsecure_invasive: Disabled,
+                secure_noninvasive: Disabled,
+                secure_invasive: Disabled,
+                cm33_invasive: Disabled,
+                cm33_noninvasive: Disabled,
+                jtag_tap: Disabled,
+                flash_mass_erase_command: Disabled,
+                isp_boot_command: Disabled,
+                fault_analysis_command: Disabled,
+                check_uuid: true,
+            },
+
+            // Fixed, Enabled
+            DebugSecurity::AllEnabled => DebugSecurityPolicies {
+                nonsecure_noninvasive: Enabled,
+                nonsecure_invasive: Enabled,
+                secure_noninvasive: Enabled,
+                secure_invasive: Enabled,
+                cm33_invasive: Enabled,
+                cm33_noninvasive: Enabled,
+                jtag_tap: Enabled,
+                flash_mass_erase_command: Enabled,
+                isp_boot_command: Enabled,
+                fault_analysis_command: Enabled,
+                check_uuid: false,
+            },
+
             DebugSecurity::Custom ( policies ) =>
                 policies,
         }

--- a/tests/test-cli.rs
+++ b/tests/test-cli.rs
@@ -21,6 +21,7 @@ fn test_factory_generates_correctly() {
 [factory-settings]
 usb-id = {{ vid = 0x1209, pid = 0xb000 }}
 rot-fingerprint = "C7EE3124 DC87EAAE 5A6F7FCC B6C2E458 706835C9 9D5D7082 4EFFAC0F 12A5A875"
+debug-settings = "AllDisabled"
 
 [factory-settings.boot-configuration]
 failure-port  = 1
@@ -58,7 +59,13 @@ dice-computation-disabled = true
     assert_eq!(data[8..12], [0x09, 0x12, 0x00, 0xb0]);
 
     // nothing
-    assert_eq!(data[0x0c.. 0x1c], [0x00u8; 0x1c - 0x0c]);
+    assert_eq!(data[0x0c.. 0x10], [0x00u8; 4]);
+
+    // debug policies
+    assert_eq!(data[0x10.. 0x18], [0xff, 0x83, 0x00, 0x7c, 0x00, 0x00, 0xff, 0xff]);
+
+    // nothing
+    assert_eq!(data[0x18.. 0x1c], [0x00u8; 0x1c - 0x18]);
 
     // secure boot cfg
     assert_eq!(data[0x1c..0x20], [0xc0, 0x00, 0x00, 0xc0]);
@@ -91,6 +98,7 @@ customer-version = 0x030201
 nonsecure-firmware-version = 0x060504
 secure-firmware-version = 0x090807
 rot-keys-status = ["Enabled", "Enabled", "Enabled", "Enabled"]
+debug-settings = "AllDisabled"
 "#).unwrap();
 
     let mut cmd = Command::cargo_bin("lpc55").unwrap();
@@ -116,9 +124,11 @@ rot-keys-status = ["Enabled", "Enabled", "Enabled", "Enabled"]
     // revocations
     assert_eq!(data[0x18 .. 0x1c], [0x55, 0, 0, 0]);
     // nothing
-    assert_eq!(data[0x1c..0x200], [0u8; 0x200 - 0x1c]);
-
-
+    assert_eq!(data[0x1c..0x20], [0u8; 4]);
+    // debug policies
+    assert_eq!(data[0x20.. 0x28], [0xff, 0x83, 0x00, 0x7c, 0x00, 0x00, 0xff, 0xff]);
+    // nothing
+    assert_eq!(data[0x28..0x200], [0u8; 0x200 - 0x28]);
 }
 
 #[test]


### PR DESCRIPTION
Fixed & tested the debug policy settings in PFR.  I changed the way of specifying them in config so they can be either turned all off or all on with one line.  Custom policies can be specified close to how they were before.

e.g.

```toml
[factory-settings]
debug-settings = "AllDisabled"
```

```toml
[factory-settings]
debug-settings = "AllEnabled"
```

```toml
[factory-settings]
debug-settings = {Custom = {nonsecure-noninvasive = "Disabled", secure-invasive = "EnableWithDap", jtag-tap = "Enabled"}}
```

Unfortunately custom debug-settings needs to be inlined currently due to [toml-rs bug](https://github.com/alexcrichton/toml-rs/issues/225), but I think it's a safer to configure secure builds this way.