### PR TITLE
Use signing key to select the correct certificate

### DIFF
--- a/example-cfgs/example-cfg.toml
+++ b/example-cfgs/example-cfg.toml
@@ -11,7 +11,6 @@ component = "0.0.0"
 product = "0.0.0"
 
 [pki]
-# certificate-slot = 0
 signing-key = "file:example-file-certs/ca_private_key_0.pem"
 # signing-key = "pkcs11:serial=DECC0401648;object=lpc55-host-dev-ca-0;type=private?module-path=/usr/lib/onepin-opensc-pkcs11.so&pin-value=123456"
 # signing-key = "pkcs11:object=lpc55-host-dev-ca-0;type=private?module-path=/usr/lib/opensc-pkcs11.so&pin-value=123456"


### PR DESCRIPTION
Binary signing was using the correct certificate, selected via the signing key's public key.
This implements the same logic for secure binary generation.