### PR TITLE
Improve bootloader selection

### DIFF
--- a/src/bin/lpc55/main.rs
+++ b/src/bin/lpc55/main.rs
@@ -4,7 +4,7 @@ use core::convert::TryFrom;
 use std::io::{self, Write as _};
 use std::fs;
 
-use anyhow::{anyhow};
+use anyhow::{Context as _, anyhow};
 use delog::hex_str;
 use log::{info, warn, trace};
 use uuid::Uuid;
@@ -54,7 +54,7 @@ fn try_main(args: clap::ArgMatches<'_>) -> anyhow::Result<()> {
 
     let uuid = args.value_of("UUID").map(Uuid::parse_str).transpose()?;
 
-    let bootloader = || Bootloader::try_find(vid, pid, uuid).ok_or(anyhow!("Could not attach to a bootloader"));
+    let bootloader = || Bootloader::try_find(vid, pid, uuid).context("Could not attach to a bootloader");
 
     if let Some(command) = args.subcommand_matches("http") {
         let bootloader = bootloader()?;

--- a/src/bootloader.rs
+++ b/src/bootloader.rs
@@ -65,19 +65,13 @@ impl Bootloader {
     /// For instance, `write-flash` on the wrong device could wreak havoc.
     pub fn try_new(vid: Option<u16>, pid: Option<u16>) -> Option<Self> {
         Self::try_find(vid, pid, None)
-        // // Bootloader is not Copy, so we can't filter
-        // let mut bootloaders = Self::list();
-        // let index = bootloaders.iter()
-        //     .position(|bootloader| bootloader.vid == vid && bootloader.pid == pid);
-        // index.map(|i| bootloaders.remove(i))
     }
 
     /// Attempt to find a ROM bootloader with the given UUID (and VID/PID pair).
     pub fn try_find(vid: Option<u16>, pid: Option<u16>, uuid: Option<Uuid>) -> Option<Self> {
-        // Bootloader is not Copy, so we can't filter
-        let mut bootloaders = Self::list();
-        let index = bootloaders.iter()
-            .position(|bootloader| {
+        Self::list()
+            .into_iter()
+            .filter(|bootloader| {
                 let mut predicate = true;
                 if vid.is_some() && pid.is_some() {
                     predicate = bootloader.vid == vid.unwrap() && bootloader.pid == pid.unwrap();
@@ -88,8 +82,8 @@ impl Bootloader {
                     }
                 }
                 predicate
-            });
-        index.map(|i| bootloaders.remove(i))
+            })
+            .next()
     }
 
     /// Returns a vector of all HID devices that appear to be ROM bootloaders

--- a/src/bootloader.rs
+++ b/src/bootloader.rs
@@ -59,7 +59,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 
 impl Bootloader {
-    /// Select first available ROM bootloader with the given VID/PID pair.
+    /// Select first available ROM bootloader with the given VID and PID.
     ///
     /// TODO: Open question is whether this is a good idea.
     /// For instance, `write-flash` on the wrong device could wreak havoc.
@@ -67,22 +67,13 @@ impl Bootloader {
         Self::try_find(vid, pid, None)
     }
 
-    /// Attempt to find a ROM bootloader with the given UUID (and VID/PID pair).
+    /// Attempt to find a ROM bootloader with the given VID, PID and UUID.
     pub fn try_find(vid: Option<u16>, pid: Option<u16>, uuid: Option<Uuid>) -> Option<Self> {
         Self::list()
             .into_iter()
-            .filter(|bootloader| {
-                let mut predicate = true;
-                if vid.is_some() && pid.is_some() {
-                    predicate = bootloader.vid == vid.unwrap() && bootloader.pid == pid.unwrap();
-                }
-                if predicate {
-                    if let Some(uuid) = uuid {
-                        predicate = bootloader.uuid == uuid.as_u128();
-                    }
-                }
-                predicate
-            })
+            .filter(|bootloader| vid.map_or(true, |vid| vid == bootloader.vid))
+            .filter(|bootloader| pid.map_or(true, |pid| pid == bootloader.pid))
+            .filter(|bootloader| uuid.map_or(true, |uuid| uuid.as_u128() == bootloader.uuid))
             .next()
     }
 


### PR DESCRIPTION
Support using only one of the --pid and --vid options and bail if multiple bootloaders match the filters instead of connecting to the first.