### PR TITLE
Add support for Debian packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,3 +79,17 @@ with-device = []
 # opt-level = 'z'
 # lto = true
 # codegen-units = 1
+
+[package.metadata.deb]
+assets = [
+    # Binary
+    ["target/release/lpc55", "usr/bin/", "755"],
+
+    # Completions
+    ["target/release/_lpc55", "usr/share/zsh/vendor-completions/", "644"],
+    ["target/release/lpc55.bash", "usr/share/bash-completion/completions/lpc55", "644"],
+
+    # udev rule
+    ["pkg/debian/70-raw-lpc55-mcuboot.rules", "usr/lib/udev/rules.d/", "644"],
+]
+extended-description = "Host-side tooling to interact with LPC55 chips via the ROM bootloader"

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -1,3 +1,3 @@
-AUR package works.
+AUR and Debian packages work.
 
 Help with homebrew (or any other distros) would be appreciated.

--- a/pkg/debian/70-raw-lpc55-mcuboot.rules
+++ b/pkg/debian/70-raw-lpc55-mcuboot.rules
@@ -1,0 +1,1 @@
+../../example-cfgs/70-raw-lpc55-mcuboot.rules

--- a/pkg/debian/Makefile
+++ b/pkg/debian/Makefile
@@ -1,0 +1,6 @@
+# Requires cargo-deb.
+# The generated package is placed at $CARGO_TARGET_DIR/debian/lpc55-*.deb.
+
+.PHONY: build
+build:
+	cargo deb --manifest-path ../../Cargo.toml


### PR DESCRIPTION
This patch adds the required metadata for Debian packages to the
Cargo.toml.  (Unfortunately, it is AFAIS not possible to place this
metadata in the pkg subdirectory.)  It also adds a Makefile in
pkg/debian that invokes cargo deb to generate the Debian package.  The
package is placed in $CARGO_TARGET_DIR/debian.

The next step would be to set up a GitHub Action that builds the package
for every release and attaches it to the release on GitHub.