### PR TITLE
Fix missing fmt argument in error message

### DIFF
--- a/src/bin/lpc55/main.rs
+++ b/src/bin/lpc55/main.rs
@@ -26,7 +26,7 @@ fn check_align(number: usize) -> anyhow::Result<()> {
     if number % 512 == 0 {
         Ok(())
     } else {
-        Err(anyhow!("{} is not a multiple of 512"))
+        Err(anyhow!("{} is not a multiple of 512", number))
     }
 }
 


### PR DESCRIPTION
Without this, the error message would literally be "{} is not a multiple of 512" with curly braces in it instead of the number.