### PR TITLE
Windows fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "lpc55"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 authors = ["Nicolas Stalder <n@stalder.io>"]
-edition = "2018"
+edition = "2021"
 description = "Host-side tooling to interact with LPC55 chips via the ROM bootloader"
 repository = "https://github.com/lpc55/lpc55-host"
 homepage = "https://github.com/lpc55/lpc55-host"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ enum-iterator = "0.7.0"
 hex = "0.4.2"
 hmac = "0.11"
 hidapi = { version = "1.2.3", default-features = false, features = ["linux-static-hidraw"] }
-nom = { version = "6" }
+nom = { version = "7" }
 serde = { version = "1", features = ["derive"] }
 serde-big-array = "0.3.0"
 serde_json = "1"
@@ -39,15 +39,15 @@ serde_yaml = "0.8.14"
 signature = "1.3.0"
 log = "0.4.11"
 lazy_static = "1.4.0"
-oid-registry = "0.1.1"
+oid-registry = "0.2"
 pem-parser = "0.1.1"
 rand = "0.8.1"
 rsa = "0.5"
 sha2 = "0.9.2"
 thiserror = "1"
-tiny_http = { version = "0.8", optional = true }
+tiny_http = { version = "0.9", optional = true }
 toml = "0.5.7"
-x509-parser = "0.9.0"
+x509-parser = "0.12"
 uriparse = "0.6.3"
 uuid = "0.8.2"
 pkcs11 = "0.5.0"
@@ -56,7 +56,7 @@ pkcs11-uri = "0.1.2"
 [dev-dependencies]
 insta = "1.1.0"
 tempfile = "3.2.0"
-assert_cmd = "1"
+assert_cmd = "2"
 predicates = "2"
 
 [build-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -29,7 +29,7 @@ fn main() {
     }
 
     // place side by side with binaries
-    let outdir = path::PathBuf::from(path::PathBuf::from(env_outdir).ancestors().skip(3).next().unwrap());
+    let outdir = path::PathBuf::from(path::PathBuf::from(env_outdir).ancestors().nth(3).unwrap());
     fs::create_dir_all(&outdir).unwrap();
     println!("{:?}", &outdir);
 

--- a/src/bin/lpc55/cli.rs
+++ b/src/bin/lpc55/cli.rs
@@ -4,7 +4,7 @@ use clap::{self, crate_authors, crate_version, App, Arg, SubCommand};
 
 // duplicated here, because when using this `cli` module in build.rs
 // to generate shell completions, there is no `lpc55` crate yet
-pub const KEYSTORE_KEY_NAMES: [&'static str; 6] = [
+pub const KEYSTORE_KEY_NAMES: [&str; 6] = [
     "secure-boot-kek",
     "user-key",
     "unique-device-secret",

--- a/src/bin/lpc55/logger.rs
+++ b/src/bin/lpc55/logger.rs
@@ -14,7 +14,7 @@ use log::{self, Log};
 #[derive(Debug)]
 pub struct Logger(());
 
-const LOGGER: &'static Logger = &Logger(());
+const LOGGER: &Logger = &Logger(());
 
 impl Logger {
     /// Create a new logger that logs to stderr and initialize it as the

--- a/src/bin/lpc55/main.rs
+++ b/src/bin/lpc55/main.rs
@@ -9,7 +9,7 @@ use delog::hex_str;
 use log::{info, warn, trace};
 use uuid::Uuid;
 
-use lpc55::bootloader::{Bootloader, command};
+use lpc55::bootloader::{Bootloader, command, UuidSelectable as _};
 
 mod cli;
 mod logger;
@@ -366,7 +366,7 @@ fn try_main(args: clap::ArgMatches<'_>) -> anyhow::Result<()> {
         let bootloader = bootloader()?;
         let filename = command.value_of("SB-FILE").unwrap();
         let image = fs::read(&filename)?;
-        bootloader.receive_sb_file(image);
+        bootloader.receive_sb_file(&image);
         return Ok(());
     }
 

--- a/src/bootloader.rs
+++ b/src/bootloader.rs
@@ -106,9 +106,8 @@ impl Bootloader {
             })
             .filter_map(|(device, vid, pid)| {
                 let protocol = Protocol::new(device);
-                let bootloader = GetProperties { protocol: &protocol }.device_uuid().ok()
-                    .map(|uuid| Self { protocol, vid, pid, uuid });
-                bootloader
+                GetProperties { protocol: &protocol }.device_uuid().ok()
+                    .map(|uuid| Self { protocol, vid, pid, uuid })
             })
             .collect()
     }

--- a/src/bootloader/command.rs
+++ b/src/bootloader/command.rs
@@ -69,10 +69,7 @@ pub enum DataPhase {
 
 impl DataPhase {
     pub fn has_command_data(&self) -> bool {
-        match self {
-            DataPhase::CommandData(_) => true,
-            _ => false,
-        }
+        matches!(self, DataPhase::CommandData(_))
     }
 }
 
@@ -93,8 +90,8 @@ impl Command {
                let mut bytes = Vec::with_capacity(words.len() * 4);
                let cursor = &mut bytes;
 
-               for i in 0 .. words.len() {
-                   cursor.write_all(&words[i].to_le_bytes()).unwrap();
+               for word in words.iter() {
+                   cursor.write_all(&word.to_le_bytes()).unwrap();
                }
 
                 DataPhase::CommandData(bytes)
@@ -483,7 +480,7 @@ pub enum Key {
 }
 
 // unfortunately duplicated in cli.rs, for why see there
-pub const KEYSTORE_KEY_NAMES: [&'static str; 6] = [
+pub const KEYSTORE_KEY_NAMES: [&str; 6] = [
     "secure-boot-kek",
     "user-key",
     "unique-device-secret",

--- a/src/bootloader/error.rs
+++ b/src/bootloader/error.rs
@@ -1,4 +1,4 @@
-//! https://github.com/NXPmicro/spsdk/blob/020a983e53769fe16cb9b49395d56f0201eccca6/spsdk/mboot/error_codes.py
+//! <https://github.com/NXPmicro/spsdk/blob/020a983e53769fe16cb9b49395d56f0201eccca6/spsdk/mboot/error_codes.py>
 
 use core::convert::TryFrom;
 
@@ -125,10 +125,10 @@ generate! { CrcCheckerError:
     OutOfRange = 4,
 }
 
-impl Into<(ErrorGroup, u8)> for BootloaderError {
-    fn into(self) -> (ErrorGroup, u8) {
+impl From<BootloaderError> for (ErrorGroup, u8) {
+    fn from(error: BootloaderError) -> Self {
         use BootloaderError::*;
-        match self {
+        match error {
             Generic(error) => (ErrorGroup::Generic, error as u8),
             FlashDriver(error) => (ErrorGroup::FlashDriver, error as u8),
             PropertyStore(error) => (ErrorGroup::PropertyStore, error as u8),
@@ -142,8 +142,7 @@ impl Into<(ErrorGroup, u8)> for BootloaderError {
 impl From<BootloaderError> for u32 {
     fn from(error: BootloaderError) -> u32 {
         let (group, code) = error.into();
-        let status = (group as u32 * 100) + code as u32;
-        status
+        (group as u32 * 100) + code as u32
     }
 }
 
@@ -158,7 +157,7 @@ impl From<u32> for BootloaderError {
                 (ErrorGroup::PropertyStore, code) => PropertyStoreError::try_from(code).map_or(Unknown(status), PropertyStore),
                 (ErrorGroup::CrcChecker, code) => CrcCheckerError::try_from(code).map_or(Unknown(status), CrcChecker),
                 (ErrorGroup::SbLoader, code) => SbLoaderError::try_from(code).map_or(Unknown(status), SbLoader),
-                _ => return Unknown(status),
+                _ => Unknown(status),
             }
         } else {
             Unknown(status)

--- a/src/bootloader/property.rs
+++ b/src/bootloader/property.rs
@@ -226,7 +226,7 @@ impl GetProperties<'_> {
             ((values[3] as u128) << 96) +
             ((values[2] as u128) << 64) +
             ((values[1] as u128) << 32) +
-            ((values[0] as u128))
+            (values[0] as u128)
             // ((u32::from_le_bytes(values[0].to_be_bytes()) as u128) << 96) +
             // ((u32::from_le_bytes(values[1].to_be_bytes()) as u128) << 64) +
             // ((u32::from_le_bytes(values[2].to_be_bytes()) as u128) << 32) +

--- a/src/bootloader/protocol.rs
+++ b/src/bootloader/protocol.rs
@@ -136,7 +136,7 @@ impl Protocol {
                 // successful status, mirroring our command header
                 let packet = ResponsePacket::try_from(initial_response)?;
 
-                assert_eq!(packet.has_data, false);
+                assert!(!packet.has_data);
                 if let Some(status) = packet.status {
                     panic!("{:?}", status);
                 }
@@ -196,7 +196,7 @@ impl Protocol {
                         }
 
                         let packet = ResponsePacket::try_from(self.read_packet()?)?;
-                        assert_eq!(packet.has_data, false);
+                        assert!(!packet.has_data);
                         if let Some(status) = packet.status {
                             panic!("unexpected status {:?}", &status);
                         }
@@ -226,7 +226,7 @@ impl Protocol {
                         }
 
                         let packet = ResponsePacket::try_from(self.read_packet()?)?;
-                        assert_eq!(packet.has_data, false);
+                        assert!(!packet.has_data);
                         if let Some(status) = packet.status {
                             panic!("unexpected status {:?}", &status);
                         }
@@ -255,7 +255,7 @@ impl Protocol {
                             x => x?,
                         })?;
                         // let packet = ResponsePacket::try_from(self.read_packet()?)?;
-                        assert_eq!(packet.has_data, false);
+                        assert!(!packet.has_data);
                         if let Some(status) = packet.status {
                             panic!("unexpected status {:?}", &status);
                         }
@@ -292,7 +292,7 @@ impl Protocol {
 
                 let packet = ResponsePacket::try_from(initial_response)?;
                 // assert_eq!([0x03, 0x00, 0x0C, 0x00], &initial_generic_response[..4]);
-                assert_eq!(packet.has_data, true);
+                assert!(!packet.has_data);
                 assert!(packet.status.is_none());
                 assert_eq!(packet.tag, command::ResponseTag::ReadMemory);
 
@@ -309,7 +309,7 @@ impl Protocol {
                 }
 
                 let packet = ResponsePacket::try_from(self.read_packet()?)?;
-                assert_eq!(packet.has_data, false);
+                assert!(!packet.has_data);
                 assert!(packet.status.is_none());
 
                 assert_eq!(packet.tag, command::ResponseTag::Generic);
@@ -395,7 +395,7 @@ impl Protocol {
         if sent >= all {
             Ok(())
         } else {
-            Err(hidapi::HidError::IncompleteSendError { sent, all })?
+            Err(hidapi::HidError::IncompleteSendError { sent, all }.into())
         }
     }
 

--- a/src/bootloader/protocol.rs
+++ b/src/bootloader/protocol.rs
@@ -392,7 +392,7 @@ impl Protocol {
     pub fn write(&self, data: &[u8]) -> Result<()> {
         let sent = self.device.write(data)?;
         let all = data.len();
-        if sent == all {
+        if sent >= all {
             Ok(())
         } else {
             Err(hidapi::HidError::IncompleteSendError { sent, all })?

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -40,9 +40,9 @@ pub fn nxp_aes_ctr_cipher(ciphertext: &[u8], dek: [u8; 32], nonce: [u32; 4], off
         let nonce3_offset = offset_blocks + (i as u32);
         let mut nonce2 = [0u8; 16];
         nonce2[..4].copy_from_slice(nonce[0].to_le_bytes().as_ref());
-        nonce2[4..8].copy_from_slice(&nonce[1].to_le_bytes().as_ref());
-        nonce2[8..12].copy_from_slice(&nonce[2].to_le_bytes().as_ref());
-        nonce2[12..16].copy_from_slice(&(nonce[3] + nonce3_offset).to_le_bytes().as_ref());
+        nonce2[4..8].copy_from_slice(nonce[1].to_le_bytes().as_ref());
+        nonce2[8..12].copy_from_slice(nonce[2].to_le_bytes().as_ref());
+        nonce2[12..16].copy_from_slice((nonce[3] + nonce3_offset).to_le_bytes().as_ref());
         let mut cipher = Aes256Ctr::new(dek.as_ref().into(), nonce2.as_ref().into());
         cipher.apply_keystream(chunk);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@
 //!
 //! There is also the somehow underadvertised <https://github.com/NXPmicro/spsdk>.
 
+// for readability
+#![allow(clippy::identity_op)]
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub mod util;
 pub mod http;
 
 // re-exports
-pub use bootloader::Bootloader;
+pub use bootloader::{Bootloader, UuidSelectable};
 pub use bootloader::Error as BootloaderError;
 pub use bootloader::protocol::Error as ProtocolError;
 pub use uuid;

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -154,8 +154,7 @@ impl SigningKey {
                 let mut hasher = sha2::Sha256::new();
                 hasher.update(data);
                 let hashed_data = hasher.finalize();
-                let signature = key.sign(padding_scheme, &hashed_data).expect("signatures work");
-                signature
+                key.sign(padding_scheme, &hashed_data).expect("signatures work")
             }
             Pkcs11Uri(uri) => {
                 let (context, session, object) = uri.identify_object().unwrap();
@@ -169,8 +168,7 @@ impl SigningKey {
 
                 // now do a signature, assuming this is an RSA key
                 context.sign_init(session, &mechanism, object).unwrap();
-                let signature = context.sign(session, data).unwrap();
-                signature
+                context.sign(session, data).unwrap()
             }
         };
         assert_eq!(256, signature.len());
@@ -209,8 +207,7 @@ impl SigningKey {
                 // https://github.com/mheese/rust-pkcs11/issues/44
                 let n = rsa::BigUint::from_bytes_be(&n.to_bytes_le());
                 let e = rsa::BigUint::from_bytes_be(&e.to_bytes_le());
-                let public_key = rsa::RsaPublicKey::new(n, e).unwrap();
-                public_key
+                rsa::RsaPublicKey::new(n, e).unwrap()
             }
         })
     }
@@ -347,7 +344,7 @@ impl Certificate {
         // let OID_RSA_ENCRYPTION = oid!(1.2.840.113549.1.1.1);
         assert_eq!(oid_registry::OID_PKCS1_RSAENCRYPTION, spki.algorithm.algorithm);
 
-        let public_key = PublicKey(rsa::RsaPublicKey::from_pkcs1_der(&spki.subject_public_key.data)?);
+        let public_key = PublicKey(rsa::RsaPublicKey::from_pkcs1_der(spki.subject_public_key.data)?);
         Ok(public_key.fingerprint())
     }
 
@@ -363,7 +360,7 @@ impl Certificate {
     pub fn public_key(&self) -> PublicKey {
         let spki = self.certificate().tbs_certificate.subject_pki;
         assert_eq!(oid_registry::OID_PKCS1_RSAENCRYPTION, spki.algorithm.algorithm);
-        PublicKey(rsa::RsaPublicKey::from_pkcs1_der(&spki.subject_public_key.data).unwrap())
+        PublicKey(rsa::RsaPublicKey::from_pkcs1_der(spki.subject_public_key.data).unwrap())
     }
 
     pub fn fingerprint(&self) -> Sha256Hash {

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -6,7 +6,7 @@ use std::{fmt, fs};
 
 use anyhow::{Context as _, Result};
 use serde::{Deserialize, Serialize};
-use x509_parser::certificate::X509Certificate;
+use x509_parser::{certificate::X509Certificate, traits::FromDer};
 
 use rsa::pkcs1::FromRsaPrivateKey;
 use rsa::pkcs1::FromRsaPublicKey;

--- a/src/protected_flash.rs
+++ b/src/protected_flash.rs
@@ -12,8 +12,8 @@ use sha2::Digest as _;
 
 use nom::{
     IResult,
+    bytes::complete::take,
     number::complete::le_u32,
-    take,
 };
 
 use serde_big_array::big_array;
@@ -385,13 +385,13 @@ impl Keystore {
 fn parse_keystore(input: &[u8]) -> IResult<&[u8], Keystore> {
     let (input, header) = le_u32(input)?;
     let (input, puf_discharge_time_milliseconds) = le_u32(input)?;
-    let (input, activation_code) = take!(input, 1192)?;
-    let (input, secure_boot_kek) = take!(input, 56)?;
-    let (input, user_key) = take!(input, 56)?;
-    let (input, unique_device_secret) = take!(input, 56)?;
-    let (input, prince_region_0) = take!(input, 56)?;
-    let (input, prince_region_1) = take!(input, 56)?;
-    let (input, prince_region_2) = take!(input, 56)?;
+    let (input, activation_code) = take(1192usize)(input)?;
+    let (input, secure_boot_kek) = take(56u8)(input)?;
+    let (input, user_key) = take(56u8)(input)?;
+    let (input, unique_device_secret) = take(56u8)(input)?;
+    let (input, prince_region_0) = take(56u8)(input)?;
+    let (input, prince_region_1) = take(56u8)(input)?;
+    let (input, prince_region_2) = take(56u8)(input)?;
 
     let keystore = Keystore {
         header: KeystoreHeader(header),
@@ -474,16 +474,16 @@ fn parse_factory<CustomerData: FactorySettingsCustomerData, VendorUsage: Factory
     let (input, prince_sr_2) = le_u32(input)?;
 
     // reserved
-    let (input, _) = take!(input, 8 * 4)?;
+    let (input, _) = take(8 * 4u8)(input)?;
 
-    let (input, rot_fingerprint) = take!(input, 32)?;
+    let (input, rot_fingerprint) = take(32u8)(input)?;
 
     // reserved
-    let (input, _) = take!(input, 9 * 4 * 4)?;
+    let (input, _) = take(9 * 4 * 4u8)(input)?;
 
-    let (input, customer_data) = take!(input, 14 * 4 * 4)?;
+    let (input, customer_data) = take(14 * 4 * 4u8)(input)?;
 
-    let (input, sha256_hash) = take!(input, 32)?;
+    let (input, sha256_hash) = take(32u8)(input)?;
 
     let factory = FactorySettings {
         boot_configuration: BootConfiguration::from(boot_cfg),
@@ -1166,7 +1166,7 @@ fn parse_customer_page<CustomerData: CustomerSettingsCustomerData, VendorUsage: 
     let (input, image_key_revocation_id) = le_u32(input)?;
 
     // reserved
-    let (input, _) = take!(input, 4)?;
+    let (input, _) = take(4u8)(input)?;
 
     let (input, rot_keys_status) = le_u32(input)?;
     let (input, vendor_usage) = le_u32(input)?;
@@ -1175,20 +1175,20 @@ fn parse_customer_page<CustomerData: CustomerSettingsCustomerData, VendorUsage: 
     let (input, enable_fa) = le_u32(input)?;
     let (input, factory_prog_in_progress) = le_u32(input)?;
 
-    let (input, prince_iv_code0) = take!(input, 14*4)?;
+    let (input, prince_iv_code0) = take(14*4u8)(input)?;
     debug!("prince IV code 0 = {}", hex_str!(prince_iv_code0));
-    let (input, prince_iv_code1) = take!(input, 14*4)?;
-    let (input, prince_iv_code2) = take!(input, 14*4)?;
+    let (input, prince_iv_code1) = take(14*4u8)(input)?;
+    let (input, prince_iv_code2) = take(14*4u8)(input)?;
 
     // reserved
-    let (input, _reserved) = take!(input, 10 * 4)?;
+    let (input, _reserved) = take(10 * 4u8)(input)?;
     debug!("reserved raw = {}", hex_str!(_reserved));
 
-    let (input, customer_data) = take!(input, 56 * 4)?;
+    let (input, customer_data) = take(56 * 4u8)(input)?;
     debug!("customer_data all zero = {}", customer_data.iter().all(|x| *x == 0));
     debug!("customer_data raw = {}", hex_str!(customer_data));
 
-    let (input, sha256_hash) = take!(input, 32)?;
+    let (input, sha256_hash) = take(32u8)(input)?;
 
     assert!(input.is_empty());
     let page = CustomerSettings {

--- a/src/protected_flash.rs
+++ b/src/protected_flash.rs
@@ -533,7 +533,7 @@ impl From<u8> for BootSpeed {
             0b00 => Nxp,
             0b01 => Fro96,
             0b10 => Fro48,
-            0b11 | _ => Reserved,
+            /*0b11 |*/ _ => Reserved,
         }
     }
 }
@@ -713,8 +713,8 @@ pub struct SecureBootConfiguration {
     pub trustzone_mode: TrustzoneMode,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]
-    /// For this DICE stuff, see also https://www.microsoft.com/en-us/research/project/dice-device-identifier-composition-engine/
-    /// and the actual standard https://trustedcomputinggroup.org/resource/hardware-requirements-for-a-device-identifier-composition-engine/
+    /// For this DICE stuff, see also <https://www.microsoft.com/en-us/research/project/dice-device-identifier-composition-engine/>
+    /// and the actual standard <https://trustedcomputinggroup.org/resource/hardware-requirements-for-a-device-identifier-composition-engine/>
     pub dice_computation_disabled: bool,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]

--- a/src/secure_binary.rs
+++ b/src/secure_binary.rs
@@ -33,7 +33,7 @@ use std::fs;
 use anyhow::{Context as _, Result};
 pub use chrono::naive::NaiveDate;
 use serde::{Deserialize, Serialize};
-use x509_parser::certificate::X509Certificate;
+use x509_parser::{certificate::X509Certificate, traits::FromDer};
 use rsa::pkcs1::FromRsaPublicKey;
 
 use nom::{
@@ -169,7 +169,7 @@ pub struct Reproducibility {
 }
 
 
-#[derive(Clone, Copy, Debug, Hash)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum Filetype {
     Elf,
     UnsignedBin,
@@ -683,6 +683,19 @@ impl SignedSb21File {
         bytes
     }
 }
+
+// impl SignedSb21File {
+//     // TODO: Convert `pub fn show` into a proper decoder
+//     pub fn read<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
+//         let data = fs::read(path.as_ref())
+//             .with_context(|| format!("Failed to read data from from {}", path.as_ref().display()))?;
+
+//         if sniff(&data)? != Filetype::Sb21 {
+//             return Err(anyhow::anyhow!("Doesn't look like an SB 2.1 file"));
+//         }
+
+//     }
+// }
 
 pub fn show(filename: &str) -> Result<Vec<u8>> {
     let data = fs::read(filename)

--- a/src/secure_binary/command.rs
+++ b/src/secure_binary/command.rs
@@ -57,9 +57,7 @@ pub struct RawBootCommand {
 
 impl RawBootCommand {
     pub fn to_bytes(&self) -> [u8; 16] {
-        let mut buffer = Vec::new();
-        buffer.push(0);
-        buffer.push(self.tag);
+        let mut buffer = vec![0, self.tag];
         buffer.extend_from_slice(self.flags.to_le_bytes().as_ref());
         buffer.extend_from_slice(self.address.to_le_bytes().as_ref());
         buffer.extend_from_slice(self.count.to_le_bytes().as_ref());

--- a/src/signed_binary.rs
+++ b/src/signed_binary.rs
@@ -45,7 +45,7 @@ impl ImageSigningRequest {
             plain_image,
             certificates,
             signing_key,
-            slot: slot,
+            slot,
         })
     }
 
@@ -74,7 +74,7 @@ impl ImageSigningRequest {
 
         let mut image = word_padded(&self.plain_image);
 
-        let certificate = word_padded(self.certificates.certificate_der(i.into()));
+        let certificate = word_padded(self.certificates.certificate_der(i));
 
         let total_image_size = modify_header(&mut image, certificate.len());
         // println!("{:x}", total_image_size);


### PR DESCRIPTION
- Windows sometimes sends a larger HID packet than data. This is fine and no longer panics.
- Methods to get semver and calver from `Version`
- Clippy cleanup
- `UuidSelectable` trait formalizing 16 bytes UUID
- update all dependencies

The next big TODO would be to implement decoders for the various types involved in signed SB2.1 files.