### PR TITLE
sb show: Add support for certificate chains and variable RSA key sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ sha2 = "0.10"
 thiserror = "1"
 tiny_http = { version = "0.9", optional = true }
 toml = "0.5.7"
-x509-parser = "0.12"
+x509-parser = { version = "0.12", features = ["verify"] }
 uriparse = "0.6.3"
 uuid = "0.8.2"
 pkcs11 = "0.5.0"

--- a/src/secure_binary.rs
+++ b/src/secure_binary.rs
@@ -730,15 +730,11 @@ pub fn show(filename: &str) -> Result<Vec<u8>> {
                         cert.tbs_certificate.version,
                         x509_parser::x509::X509Version::V3
                     );
-                    if certificates.len() != 0 {
-                        assert!(cert
-                            .verify_signature(Some(
-                                certificates[certificates.len() - 1].public_key()
-                            ))
-                            .is_ok());
-                    } else {
-                        assert!(cert.verify_signature(None).is_ok());
-                    }
+
+                    // Verify that the certificate is signed by the previous certificate, or by
+                    // itself if it is the first.
+                    let prev_public_key = certificates.last().map(|c| c.public_key());
+                    assert!(cert.verify_signature(prev_public_key).is_ok());
                     certificates.push(cert);
                 }
                 _ => panic!("Invalid certificate"),


### PR DESCRIPTION
The `sb show` command only accepted `sb2` files with a single certificate with an RSA 2048bit key. This PR adds basic supports for files using a chain of certificates and other RSA key sizes.