### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/bin/lpc55/cli.rs
+++ b/src/bin/lpc55/cli.rs
@@ -35,7 +35,8 @@ pub fn app() -> clap::Command<'static> {
         .version(crate_version!())
         .long_version(LONG_VERSION.as_str())
         .about(ABOUT)
-        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .subcommand_required(true)
+        .arg_required_else_help(true)
 
 
         .arg(Arg::new("VID")
@@ -92,7 +93,8 @@ pub fn app() -> clap::Command<'static> {
             .version(crate_version!())
             .long_version(LONG_VERSION.as_str())
             .about("configure factory and customer settings")
-            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+            .subcommand_required(true)
+            .arg_required_else_help(true)
 
             .subcommand(Command::new("factory-settings")
                 .version(crate_version!())
@@ -160,7 +162,8 @@ pub fn app() -> clap::Command<'static> {
             .version(crate_version!())
             .long_version(LONG_VERSION.as_str())
             .about("keystore interactions")
-            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+            .subcommand_required(true)
+            .arg_required_else_help(true)
 
             .subcommand(Command::new("enroll-puf")
                 .version(crate_version!())

--- a/src/bin/lpc55/cli.rs
+++ b/src/bin/lpc55/cli.rs
@@ -20,7 +20,7 @@ Use -h for short descriptions and --help for more details
 
 Project homepage: https://github.com/lpc55/lpc55-host
 ";
-pub fn app() -> Command<'static> {
+pub fn app() -> clap::Command<'static> {
     // We need to specify our version in a static because we've painted clap
     // into a corner. We've told it that every string we give it will be
     // 'static, but we need to build the version string dynamically. We can
@@ -35,7 +35,7 @@ pub fn app() -> Command<'static> {
         .version(crate_version!())
         .long_version(LONG_VERSION.as_str())
         .about(ABOUT)
-        .subcommand_required(true)
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
 
 
         .arg(Arg::new("VID")
@@ -92,7 +92,7 @@ pub fn app() -> Command<'static> {
             .version(crate_version!())
             .long_version(LONG_VERSION.as_str())
             .about("configure factory and customer settings")
-            .subcommand_required(true)
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
 
             .subcommand(Command::new("factory-settings")
                 .version(crate_version!())
@@ -160,7 +160,7 @@ pub fn app() -> Command<'static> {
             .version(crate_version!())
             .long_version(LONG_VERSION.as_str())
             .about("keystore interactions")
-            .subcommand_required(true)
+            .setting(clap::AppSettings::SubcommandRequiredElseHelp)
 
             .subcommand(Command::new("enroll-puf")
                 .version(crate_version!())


### PR DESCRIPTION
Clap has renamed some functionality in recent releases and added deprecation warnings for old names. This PR fixes the warnings.

The diff only looks big because #20 should be merged first as this PR branches from #20.