### PR TITLE
Add support for creating SB2 images with 4096 bit RSA keys

### DIFF
--- a/src/pki.rs
+++ b/src/pki.rs
@@ -116,10 +116,8 @@ impl PublicKey {
     }
 }
 
-const SIGNATURE_LENGTH: usize = 256;
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Signature(pub [u8; SIGNATURE_LENGTH]);
+#[derive(Clone, Debug, PartialEq)]
+pub struct Signature(pub Vec<u8>);
 
 impl SigningKey {
     pub fn try_from_uri(uri: &str) -> anyhow::Result<Self> {
@@ -179,10 +177,7 @@ impl SigningKey {
                 context.sign(session, data).unwrap()
             }
         };
-        assert_eq!(256, signature.len());
-        let mut array = [0u8; SIGNATURE_LENGTH];
-        array.copy_from_slice(&signature);
-        Signature(array)
+        Signature(signature)
     }
 
     pub fn public_key(&self) -> PublicKey {
@@ -229,12 +224,7 @@ impl<'a> core::convert::TryFrom<&'a [u8]> for Signature {
     type Error = signature::Error;
 
     fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
-        if bytes.len() != SIGNATURE_LENGTH {
-            return Err(signature::Error::new());
-        }
-        let mut array = [0u8; SIGNATURE_LENGTH];
-        array.copy_from_slice(bytes);
-        Ok(Signature(array))
+        Ok(Signature(Vec::from(bytes)))
     }
 }
 

--- a/src/secure_binary.rs
+++ b/src/secure_binary.rs
@@ -550,7 +550,14 @@ impl UnsignedSb21File {
     pub fn boot_tag_offset_blocks(&self) -> usize {
         // entire header section is "data to be signed" + signature
         // a block is 16 bytes
-        (self.signed_data_length() + 256) / 16
+        (self.signed_data_length()
+            + self
+                .certificates
+                .certificate(self.slot)
+                .public_key()
+                .0
+                .size())
+            / 16
     }
 
     // alright, BootTag, Hmac, Section


### PR DESCRIPTION
Similar to #19, but this time for SB2 file creation.

I generated my own certificates for testing. 

I also noticed that despite being in the README, `lpc55 sign-fw example-cfgs/example-cfg.toml` and `lpc55 assemble-sb example-cfgs/example-cfg.toml` don't work, because there are no file called `example-binaries/blinky-red-bee.bin` and the signed files loaded in the `command` section are called `example-binaries/blinky-red-signed.bin` while the top config calls it `example-binaries/blinky-red-signed.bin2`