### PR TITLE
Fix assert broken in 4a30bef

### DIFF
--- a/src/bootloader/protocol.rs
+++ b/src/bootloader/protocol.rs
@@ -323,7 +323,7 @@ impl Protocol {
             (command::Command::ReadMemory { address: _, length }, _, _) => {
                 let packet = ResponsePacket::try_from(initial_response)?;
                 // assert_eq!([0x03, 0x00, 0x0C, 0x00], &initial_generic_response[..4]);
-                assert!(!packet.has_data);
+                assert!(packet.has_data);
                 assert!(packet.status.is_none());
                 assert_eq!(packet.tag, command::ResponseTag::ReadMemory);
 


### PR DESCRIPTION
This assertion was broken when they were all changed from `assert_eq!(packet.has_data, false);` to `assert!(!packet.has_data);` as all instances *except this one* were asserting equal to false. This fixes the logic inversion and gets the utility working again on any commands that read memory.