### PR TITLE
Fix toml-formatted PFR (de-)serialization

### DIFF
--- a/src/bin/lpc55/main.rs
+++ b/src/bin/lpc55/main.rs
@@ -300,7 +300,7 @@ fn try_main(args: clap::ArgMatches) -> anyhow::Result<()> {
                     io::stdout().write_all(&data).unwrap()
                 }
             }
-            "toml" => println!("{}", toml::to_string(&pfr).unwrap()),
+            "toml" => println!("{}", toml::Value::try_from(&pfr).unwrap()),
             "yaml" => println!("{}", serde_yaml::to_string(&pfr).unwrap()),
             // "yaml-pretty" => println!("{}", serde_yaml::to_string_pretty(&pfr).unwrap()),
             _ => panic!(),

--- a/src/protected_flash.rs
+++ b/src/protected_flash.rs
@@ -32,13 +32,14 @@ pub const CUSTOMER_SETTINGS_SCRATCH_ADDRESS: usize = 0x9_DE00;
 /// - factory page: one flash page (512B) of configuration data, to be set during manufacturing process
 /// - keystore: three flash pages, technically considered part of the factory configuration data,
 /// containing activation and key codes for the PUF keys.
+#[serde(rename_all = "kebab-case")]
 pub struct ProtectedFlash {
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]
     pub customer: CustomerSettingsArea,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]
-    pub factory: FactorySettings,
+    pub factory_settings: FactorySettings,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]
     pub keystore: Keystore,
@@ -95,7 +96,6 @@ where
     pub rot_fingerprint: Sha256Hash,
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]
-    #[serde(serialize_with = "hex_serialize")]
     /// 224 bytes that the customer can use.
     pub customer_data: CustomerData,
     #[serde(default)]
@@ -869,13 +869,13 @@ bitflags::bitflags! {
 impl core::convert::TryFrom<&[u8]> for ProtectedFlash {
     type Error = ();
     fn try_from(input: &[u8]) -> ::std::result::Result<Self, Self::Error> {
-        let factory = FactorySettings::try_from(&input[3 * 512..4 * 512]).unwrap();
+        let factory_settings = FactorySettings::try_from(&input[3 * 512..4 * 512]).unwrap();
         let customer = CustomerSettingsArea::try_from(&input[..3 * 512]).unwrap();
         let keystore = Keystore::try_from(&input[4 * 512..7 * 512]).unwrap();
 
         let pfr = ProtectedFlash {
             customer,
-            factory,
+            factory_settings,
             keystore,
         };
 


### PR DESCRIPTION
This fixes the serialization of PFR data to toml, as described in the linked issue.

Without this patch, I get the following error:
```
$ lpc55 pfr --format toml
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ValueAfterTable', src/bin/lpc55/main.rs:303:60
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The second commit also changes the output format so that the TOML file can be used unmodified in the `lpc55 configure factory-settings` command. Before this it was throwing an error that `factory-settings` was missing (it was originally named `factory`, and that `factory-settings.customer-data` should be an array rather than a string:
```
$ ./target/debug/lpc55 configure factory-settings -o out.bin fact.toml 
Error: missing field `factory-settings` at line 12 column 1
```

```
$ ./target/debug/lpc55 configure factory-settings -o out.bin fact.toml
Error: invalid type: string "XXXXXXXX......XXXXXXXX", expected an array of length 224 for key `factory-settings.customer-data` at line 2 column 17
```