### PR TITLE
Add support for non root signing certificates

### DIFF
--- a/src/bootloader.rs
+++ b/src/bootloader.rs
@@ -92,7 +92,7 @@ impl fmt::Display for Bootloader {
 ///
 /// TODO: To implement StdError via thiserror::Error, we need to
 /// add error messages to all the error variants.
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Error {
     Generic(error::GenericError),
     FlashDriver(error::FlashDriverError),

--- a/src/bootloader/command.rs
+++ b/src/bootloader/command.rs
@@ -362,7 +362,7 @@ impl TryFrom<u8> for ReportId {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Version {
     pub mark: Option<char>,
     pub major: u8,

--- a/src/bootloader/error.rs
+++ b/src/bootloader/error.rs
@@ -48,7 +48,7 @@ macro_rules! generate {
     ($Error:ident: $($error:ident = $code:literal,)*) => {
 
         #[repr(u8)]
-        #[derive(Copy, Clone, Debug, Deserialize, enum_iterator::IntoEnumIterator, PartialEq, Serialize)]
+        #[derive(Copy, Clone, Debug, Deserialize, enum_iterator::IntoEnumIterator, Eq, PartialEq, Serialize)]
         pub enum $Error { $(
             $error = $code,
         )* }

--- a/src/bootloader/property.rs
+++ b/src/bootloader/property.rs
@@ -9,7 +9,7 @@ pub struct GetProperties<'a> {
     pub protocol: &'a Protocol,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Properties {
     pub current_version: Version,
     pub target_version: Version,
@@ -121,7 +121,7 @@ bitflags::bitflags! {
 }
 
 #[repr(u32)]
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum PfrKeystoreUpdateOptions {
     Keystore = 0x00,
     WriteMemory = 0x01,
@@ -138,7 +138,7 @@ impl From<u32> for PfrKeystoreUpdateOptions {
     }
 }
 
-#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct IrqNotificationPin {
     pub pin: u8,
     pub port: u8,

--- a/src/http.rs
+++ b/src/http.rs
@@ -62,10 +62,6 @@ impl Server {
                 "/status" => Some(self.status()?),
                 _ => None,
             },
-            http::Method::Post => match request.url() {
-                // "/api" => Some(self.api(&mut request)?),
-                _ => None,
-            },
             _ => None,
         }
         .unwrap_or_else(|| {

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -520,6 +520,7 @@ impl Certificates {
         self.chains[usize::from(i)].signer()
     }
 
+    /// Get the DER reprensentation for the end of chain certificate from the chain
     pub fn certificate_der(&self, i: CertificateSlot) -> &[u8] {
         self.certificate(i).der()
     }

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -54,6 +54,18 @@ pub struct Pki {
     pub certificates: [String; 4],
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[serde(untagged)]
+pub enum CertificateUriChain {
+    Root(String),
+    Chain {
+        root: String,
+        #[serde(default)]
+        chain: Vec<String>,
+    },
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 /// Type enabling `lpc55 rotkh` to share config file with the secure/signed

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -13,7 +13,7 @@ use rsa::pkcs1::FromRsaPublicKey;
 
 use crate::util::is_default;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SigningKeySource {
     Pkcs1PemFile(std::path::PathBuf),
     Pkcs11Uri(std::string::String),
@@ -25,7 +25,7 @@ pub fn split_once(s: &str, delimiter: char) -> Option<(&str, &str)> {
 }
 
 /// Specification of PKI for secure (signed) boot.
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct Pki {
@@ -54,7 +54,7 @@ pub struct Pki {
     pub certificates: [CertificateUriChain; 4],
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(untagged)]
 pub enum CertificateUriChain {
@@ -82,7 +82,7 @@ impl CertificateUriChain {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 /// Type enabling `lpc55 rotkh` to share config file with the secure/signed
 /// firmware generation commands. Serializes `Pki` with a `[pki]` header.
@@ -126,7 +126,7 @@ pub enum SigningKey {
 }
 
 /// An RSA2k public key
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PublicKey(pub rsa::RsaPublicKey);
 
 impl PublicKey {
@@ -144,7 +144,7 @@ impl PublicKey {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Signature(pub Vec<u8>);
 
 impl SigningKey {
@@ -278,7 +278,7 @@ impl signature::Signer<Signature> for SigningKey {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CertificateSlot(usize);
 
 // This should not be necessary; not having it would prevent
@@ -301,7 +301,7 @@ impl From<CertificateSlot> for usize {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CertificateSource {
     X509DerFile(std::path::PathBuf),
     Pkcs11Uri(std::string::String),
@@ -433,7 +433,7 @@ impl CertificateChain {
             .chain()
             .iter()
             .map(|uri| {
-                let s: &str = &*uri;
+                let s: &str = uri;
                 Certificate::try_from(&s.try_into()?)
             })
             .collect();

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -69,8 +69,8 @@ pub enum CertificateUriChain {
 impl CertificateUriChain {
     pub fn root(&self) -> &str {
         match self {
-            Self::Root(r) => &r,
-            Self::Chain { root, chain: _ } => &root,
+            Self::Root(r) => r,
+            Self::Chain { root, chain: _ } => root,
         }
     }
 
@@ -456,6 +456,7 @@ impl CertificateChain {
         std::iter::once(&self.root).chain(self.chain.iter())
     }
 
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         1 + self.chain.len()
     }
@@ -516,7 +517,7 @@ impl Certificates {
 
     /// Get the end of chain certificate from the chain
     pub fn certificate(&self, i: CertificateSlot) -> &Certificate {
-        &self.chains[usize::from(i)].signer()
+        self.chains[usize::from(i)].signer()
     }
 
     pub fn certificate_der(&self, i: CertificateSlot) -> &[u8] {

--- a/src/secure_binary.rs
+++ b/src/secure_binary.rs
@@ -465,7 +465,6 @@ impl UnsignedSb21File {
         for mut certificate_der in self.certificates.chain_der(self.slot).map(Vec::from) {
             let unpadded_cert_length = certificate_der.len();
             let padded_len = 4 * ((unpadded_cert_length + 3) / 4);
-            dbg!((padded_len, unpadded_cert_length));
             certificate_der.resize(padded_len, 0);
             padded_certs.push(certificate_der);
         }
@@ -546,7 +545,10 @@ impl UnsignedSb21File {
 
     pub fn signed_data_length(&self) -> usize {
         // need "padded" length here
-        let certificate_length = 4 * ((self.certificates.certificate_der(self.slot).len() + 3) / 4);
+        let certificate_length = self
+            .certificates
+            .chain_der(self.slot)
+            .fold(0, |acc, der| acc + 4 * ((der.len() + 3) / 4));
 
         // let header_blocks = 16;
         // let keyblob_blocks = 5;

--- a/src/secure_binary.rs
+++ b/src/secure_binary.rs
@@ -314,8 +314,6 @@ pub struct Sb21HeaderPart {
     // not sure if the 8 bytes padding can be set to zero or not
     encrypted_keyblob: [u8; 80],
     certificate_block_header: FullCertificateBlockHeader,
-    #[allow(dead_code)]
-    unpadded_cert_length: usize,
     padded_certificate0_der: Vec<u8>,
     rot_fingerprints: [Sha256Hash; 4],
 }
@@ -518,7 +516,6 @@ impl UnsignedSb21File {
             digest,
             encrypted_keyblob,
             certificate_block_header,
-            unpadded_cert_length,
             padded_certificate0_der,
             rot_fingerprints,
         }

--- a/src/secure_binary.rs
+++ b/src/secure_binary.rs
@@ -122,7 +122,7 @@ pub struct Firmware {
     pub product: Version,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct Reproducibility {

--- a/src/secure_binary/command.rs
+++ b/src/secure_binary/command.rs
@@ -25,7 +25,7 @@ use crate::util::is_default;
 const START_OF_PROTECTED_FLASH: u32 = 0x9_DE00;
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BootTag {
     Nop = 0,
     Tag = 1,
@@ -44,7 +44,7 @@ pub enum BootTag {
 }
 
 // struct boot_command_t
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct RawBootCommand {
     pub checksum: u8,
     pub tag: u8,
@@ -130,7 +130,7 @@ impl RawBootCommand {
 /// file = "example.sb2"
 /// len = 512
 /// ```
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "cmd")]
 pub enum SingleBootCommandDescription {
     /// Maps to `BootCommand::EraseRegion`, but `start` and `end` are given in bytes.
@@ -184,7 +184,7 @@ pub enum SingleBootCommandDescription {
 /// image = "Signed"
 /// ```
 ///
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "seq")]
 pub enum BootCommandSequenceDescription {
     /// Takes the filename specified in image from `config.firmware`,
@@ -211,7 +211,7 @@ pub enum BootCommandSequenceDescription {
     CheckDerivedFirmwareVersions,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum BootCommandDescription {
     Single(SingleBootCommandDescription),
@@ -259,7 +259,7 @@ impl<'a> TryFrom<&'a SingleBootCommandDescription> for BootCommand {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 // The LPC55xx ROM loader provides the support for the following bootloader commands:
 // * WriteMemory, FillMemory, ConfigureMemory, FlashEraseAll, FlashEraseRegion,
 // SB 2.1 introduces two new commands that can be used to prevent firmware roll-back:

--- a/src/signed_binary.rs
+++ b/src/signed_binary.rs
@@ -87,11 +87,9 @@ impl ImageSigningRequest {
         image.extend_from_slice(&certificate);
 
         // ROT key hash table
-        for i in 0..4 {
-            let fingerprint = self.certificates.certificate(i.into()).fingerprint();
-            image.extend_from_slice(&fingerprint.0);
+        for h in self.certificates.fingerprints() {
+            image.extend_from_slice(&h.0);
         }
-
         image
     }
 }

--- a/src/signed_binary.rs
+++ b/src/signed_binary.rs
@@ -1,9 +1,8 @@
-use core::convert::TryFrom;
 use std::fs;
 
 use anyhow::{Context as _, Result};
 
-use crate::pki::{Certificate, CertificateSlot, CertificateSource, Certificates, SigningKey};
+use crate::pki::{Certificate, CertificateSlot, Certificates, SigningKey};
 use crate::secure_binary::Config;
 use crate::util::word_padded;
 
@@ -30,14 +29,7 @@ impl ImageSigningRequest {
                 config.firmware.image
             )
         })?;
-
-        let certificate_sources = [
-            CertificateSource::try_from(config.pki.certificates[0].as_ref())?,
-            CertificateSource::try_from(config.pki.certificates[1].as_ref())?,
-            CertificateSource::try_from(config.pki.certificates[2].as_ref())?,
-            CertificateSource::try_from(config.pki.certificates[3].as_ref())?,
-        ];
-        let certificates = Certificates::try_from(&certificate_sources)?;
+        let certificates = Certificates::try_from_pki(&config.pki)?;
 
         let signing_key = SigningKey::try_from_uri(config.pki.signing_key.as_ref())?;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -64,11 +64,15 @@ where
     Ok(t)
 }
 
+/// Length after block padding
+pub fn block_pad_len(len: usize) -> usize {
+    16 * ((len + 15) / 16)
+}
+
 /// Pad to multiple of AES block (16 bytes = 128 bits)
 pub fn block_pad(data: &mut Vec<u8>) {
     let size = data.len();
-    let aligned_size = 16 * ((size + 15) / 16);
-    data.resize(aligned_size, 0);
+    data.resize(block_pad_len(size), 0);
 }
 
 /// Padded to multiple of AES block (16 bytes = 128 bits)
@@ -78,11 +82,15 @@ pub fn block_padded(data: &[u8]) -> Vec<u8> {
     data
 }
 
+/// Length after word-padding
+pub fn word_pad_len(len: usize) -> usize {
+    4 * ((len + 3) / 4)
+}
+
 /// Pad to multiple of machine word (4 bytes = 32 bits)
 pub fn word_pad(data: &mut Vec<u8>) {
     let size = data.len();
-    let aligned_size = 4 * ((size + 3) / 4);
-    data.resize(aligned_size, 0);
+    data.resize(word_pad_len(size), 0);
 }
 
 /// Padded to multiple of machine word (4 bytes = 32 bits)


### PR DESCRIPTION
This PR allows using chain certificates in `sign-fw` and `assemble-sb`. Previously only root certificates could be used for signing. Now chain certificates can be specified in the config file like this:

```toml
certificates = [
    {root = "file:example-file-certs/ca_certificate_0.der", chain = ["file:example-file-certs/ca_certificate_0_1.der", "file:example-file-certs/ca_certificate_0_2.der"]},
    "file:example-file-certs/ca_certificate_1.der",
    "file:example-file-certs/ca_certificate_2.der",
    "file:example-file-certs/ca_certificate_3.der",
]
```

This is backwards compatible with signing directly with a root certificate using the schema:

```toml
certificates = [
    "file:example-file-certs/ca_certificate_0.der",
    "file:example-file-certs/ca_certificate_1.der",
    "file:example-file-certs/ca_certificate_2.der",
    "file:example-file-certs/ca_certificate_3.der",
]
```

This PR is built on to of my previous PR #24 