### PR TITLE
Bump all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## [0.2.0] - 2022-??-??
+
+- breaking change: bump `uuid` to v1 (exposed directly)
+- bump all dependencies
+
 ## [0.1.2] - 2022-09-19
 
 - remove ancient `pem-parser`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lpc55"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Nicolas Stalder <n@stalder.io>"]
 edition = "2021"
 description = "Host-side tooling to interact with LPC55 chips via the ROM bootloader"
@@ -18,43 +18,43 @@ name = "lpc55"
 required-features = ["cli"]
 
 [dependencies]
-aes = "0.7"
+aes = "0.8"
 anyhow = "1"
 atty = "0.2.14"
 base64 = "0.13"
 bitflags = "1.2.1"
 chrono = "0.4.19"
 clap = { version = "3", features = ["cargo"], optional = true }
-ctr = "0.8"
+ctr = "0.9"
 delog = "0.1.0-alpha.2"
-enum-iterator = "0.7.0"
+enum-iterator = "1"
 hex = "0.4.2"
 hmac = "0.12"
 hidapi = { version = "1.2.3", default-features = false, features = ["linux-static-hidraw"] }
 nom = { version = "7" }
 serde = { version = "1", features = ["derive"] }
-serde-big-array = "0.3.0"
+serde-big-array = "0.4.0"
 serde_json = "1"
-serde_yaml = "0.8.14"
+serde_yaml = "0.9"
 signature = "1.3.0"
 log = "0.4.11"
 lazy_static = "1.4.0"
-oid-registry = "0.2"
+oid-registry = "0.6"
 pem = "1.1"
 rand = "0.8.1"
-rsa = "0.5"
+rsa = "0.6"
 sha2 = "0.10"
 thiserror = "1"
-tiny_http = { version = "0.9", optional = true }
+tiny_http = { version = "0.11", optional = true }
 toml = "0.5.7"
-x509-parser = { version = "0.12", features = ["verify"] }
+x509-parser = { version = "0.14", features = ["verify"] }
 uriparse = "0.6.3"
-uuid = "0.8.2"
+uuid = "1"
 pkcs11 = "0.5.0"
 pkcs11-uri = "0.1.2"
 
 # progressbar
-indicatif = { version = "0.16.2", optional = true }
+indicatif = { version = "0.17", optional = true }
 
 [dev-dependencies]
 insta = "1.1.0"

--- a/src/bootloader.rs
+++ b/src/bootloader.rs
@@ -6,7 +6,7 @@
 use core::fmt;
 
 use anyhow::anyhow;
-use enum_iterator::IntoEnumIterator;
+use enum_iterator::all;
 use hidapi::HidApi;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -50,12 +50,12 @@ pub trait UuidSelectable: Sized {
             })
             .collect();
         match candidates.len() {
-            0 => Err(anyhow!("No candidate has UUID {:X}", uuid.to_simple())),
+            0 => Err(anyhow!("No candidate has UUID {:X}", uuid.simple())),
             1 => Ok(candidates.remove(0)),
             n => Err(anyhow!(
                 "Multiple ({}) candidates have UUID {:X}",
                 n,
-                uuid.to_simple()
+                uuid.simple()
             )),
         }
     }
@@ -115,15 +115,12 @@ impl UuidSelectable for Bootloader {
             .filter(|bootloader| bootloader.uuid() == uuid)
             .collect();
         match candidates.len() {
-            0 => Err(anyhow!(
-                "No usable bootloader has UUID {:X}",
-                uuid.to_simple()
-            )),
+            0 => Err(anyhow!("No usable bootloader has UUID {:X}", uuid.simple())),
             1 => Ok(candidates.remove(0)),
             n => Err(anyhow!(
                 "Multiple ({}) bootloaders have UUID {:X}",
                 n,
-                uuid.to_simple()
+                uuid.simple()
             )),
         }
     }
@@ -205,7 +202,7 @@ impl Bootloader {
     }
 
     pub fn info(&self) {
-        for property in Property::into_enum_iter() {
+        for property in all::<Property>() {
             // println!("\n{:?}", property);
             self.property(property).ok();
         }

--- a/src/bootloader/command.rs
+++ b/src/bootloader/command.rs
@@ -45,9 +45,7 @@ pub enum Command {
 }
 
 #[repr(u8)]
-#[derive(
-    Clone, Copy, Debug, Eq, Hash, enum_iterator::IntoEnumIterator, Ord, PartialEq, PartialOrd,
-)]
+#[derive(Clone, Copy, Debug, Eq, Hash, enum_iterator::Sequence, Ord, PartialEq, PartialOrd)]
 pub enum CommandTag {
     EraseFlashAll = 0x01,
     EraseFlash = 0x02,
@@ -286,9 +284,7 @@ impl Command {
 }
 
 #[repr(u8)]
-#[derive(
-    Clone, Copy, Debug, Eq, Hash, enum_iterator::IntoEnumIterator, Ord, PartialEq, PartialOrd,
-)]
+#[derive(Clone, Copy, Debug, Eq, Hash, enum_iterator::Sequence, Ord, PartialEq, PartialOrd)]
 pub enum ResponseTag {
     Generic = 0xA0,
     ReadMemory = 0xA3,
@@ -337,9 +333,7 @@ impl Response {
 }
 
 #[repr(u8)]
-#[derive(
-    Clone, Copy, Debug, Eq, Hash, enum_iterator::IntoEnumIterator, Ord, PartialEq, PartialOrd,
-)]
+#[derive(Clone, Copy, Debug, Eq, Hash, enum_iterator::Sequence, Ord, PartialEq, PartialOrd)]
 // todo: rename to HidReportId? place in `mod hid` submodule?
 pub enum ReportId {
     Command = 1,

--- a/src/bootloader/error.rs
+++ b/src/bootloader/error.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use super::Error as BootloaderError;
 
 #[repr(u8)]
-#[derive(Clone, Debug, enum_iterator::IntoEnumIterator)]
+#[derive(Clone, Debug, enum_iterator::Sequence)]
 pub enum ErrorGroup {
     Generic = 0,
     FlashDriver = 1,
@@ -48,7 +48,7 @@ macro_rules! generate {
     ($Error:ident: $($error:ident = $code:literal,)*) => {
 
         #[repr(u8)]
-        #[derive(Copy, Clone, Debug, Deserialize, enum_iterator::IntoEnumIterator, Eq, PartialEq, Serialize)]
+        #[derive(Copy, Clone, Debug, Deserialize, enum_iterator::Sequence, Eq, PartialEq, Serialize)]
         pub enum $Error { $(
             $error = $code,
         )* }

--- a/src/bootloader/property.rs
+++ b/src/bootloader/property.rs
@@ -39,7 +39,7 @@ pub struct Properties {
     Debug,
     Eq,
     Hash,
-    enum_iterator::IntoEnumIterator,
+    enum_iterator::Sequence,
     Ord,
     PartialEq,
     PartialOrd,

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,5 +1,7 @@
 //! NXP's CRC32 and AES-CTR algorithms
 
+use ctr::cipher::KeyIvInit as _;
+
 pub fn sha256(data: &[u8]) -> [u8; 32] {
     use sha2::Digest;
     let mut hasher = sha2::Sha256::new();
@@ -34,7 +36,6 @@ pub fn nxp_aes_ctr_cipher(
     offset_blocks: u32,
 ) -> Vec<u8> {
     type Aes256Ctr = ctr::Ctr32BE<aes::Aes256>;
-    use ctr::cipher::NewCipher;
     use ctr::cipher::StreamCipher;
 
     let mut plaintext = Vec::from(ciphertext);

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -5,11 +5,9 @@ use std::convert::{TryFrom, TryInto};
 use std::{fmt, fs};
 
 use anyhow::{Context as _, Result};
+use rsa::pkcs1::{DecodeRsaPrivateKey as _, DecodeRsaPublicKey as _};
 use serde::{Deserialize, Serialize};
-use x509_parser::{certificate::X509Certificate, traits::FromDer};
-
-use rsa::pkcs1::FromRsaPrivateKey;
-use rsa::pkcs1::FromRsaPublicKey;
+use x509_parser::{certificate::X509Certificate, prelude::FromDer as _};
 
 use crate::util::is_default;
 
@@ -384,7 +382,7 @@ impl Certificate {
         );
 
         let public_key = PublicKey(rsa::RsaPublicKey::from_pkcs1_der(
-            spki.subject_public_key.data,
+            &spki.subject_public_key.data,
         )?);
         Ok(public_key.fingerprint())
     }
@@ -404,7 +402,7 @@ impl Certificate {
             oid_registry::OID_PKCS1_RSAENCRYPTION,
             spki.algorithm.algorithm
         );
-        PublicKey(rsa::RsaPublicKey::from_pkcs1_der(spki.subject_public_key.data).unwrap())
+        PublicKey(rsa::RsaPublicKey::from_pkcs1_der(&spki.subject_public_key.data).unwrap())
     }
 
     pub fn fingerprint(&self) -> Sha256Hash {

--- a/src/protected_flash.rs
+++ b/src/protected_flash.rs
@@ -12,11 +12,7 @@ use sha2::Digest as _;
 
 use nom::{bytes::complete::take, number::complete::le_u32, IResult};
 
-use serde_big_array::big_array;
-big_array! {
-    BigArray;
-    +1192,
-}
+use serde_big_array::BigArray;
 
 pub mod debug;
 pub use debug::{DebugAccess, DebugSettings};


### PR DESCRIPTION
Mildly breaking change as we expose `uuid::Uuid` directly, and e.g. `uuid.to_simple()` became `uuid.simple()`